### PR TITLE
fix mismatching braces bug

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -152,6 +152,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   config_stack.push(config);
   TokenType last_token_type = TOKEN_TYPE_START;
   TokenType token_type;
+  int numStartedBlocks = 0;         // Number of blocks started
   while (true) {
     std::string token;
     token_type = ParseToken(config_file, &token);
@@ -194,6 +195,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
+      numStartedBlocks++;   // Increment number of started blocks
       NginxConfig* const new_config = new NginxConfig;
       config_stack.top()->statements_.back().get()->child_block_.reset(
           new_config);
@@ -203,8 +205,13 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
         // Error.
         break;
       }
+      numStartedBlocks--;   // Decrement number of started blocks
       config_stack.pop();
     } else if (token_type == TOKEN_TYPE_EOF) {
+      if (numStartedBlocks != 0) {
+        printf("Mismatched curly braces");
+        return false;
+      }
       if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
           last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -9,3 +9,44 @@ TEST(NginxConfigParserTest, SimpleConfig) {
 
   EXPECT_TRUE(success);
 }
+
+TEST(NginxConfigTest, ToString) {
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("foo");
+	statement.tokens_.push_back("bar");
+	EXPECT_EQ(statement.ToString(0), "foo bar;\n");
+}
+
+TEST(NginxConfigParserTest, ExtraEndBraceConfig) {
+  NginxConfigParser parser;
+  NginxConfig out_config;
+
+  std::stringstream config_stream("server { listen   80; server_name foo.com; root /home/ubuntu/sites/foo/; }}");
+
+  bool success = parser.Parse(&config_stream, &out_config);
+
+  EXPECT_FALSE(success);
+}
+
+TEST(NginxConfigParserTest, MultipleBlockConfig) {
+  NginxConfigParser parser;
+  NginxConfig out_config;
+
+  std::stringstream config_stream("server { listen   80; server_name foo.com; client { listen 10; } root /home/ubuntu/sites/foo/; }");
+
+  bool success = parser.Parse(&config_stream, &out_config);
+
+  EXPECT_TRUE(success);
+}
+
+// The following test fails with the given config_parser.cc code. The bug has been fixed and the test now passes.
+TEST(NginxConfigParserTest, MissingEndBraceConfig) {
+  NginxConfigParser parser;
+  NginxConfig out_config;
+
+  std::stringstream config_stream("server { listen   80; server_name foo.com; root /home/ubuntu/sites/foo/; ");
+
+  bool success = parser.Parse(&config_stream, &out_config);
+
+  EXPECT_FALSE(success);
+}


### PR DESCRIPTION
I found that configs with an unequal number of start and end curly braces are parsed as valid. I fixed the parser code so that it returns false if the config file has mismatching curly braces.